### PR TITLE
Classes

### DIFF
--- a/datapacks/bc_classes/data/common/powers/starting_items.json
+++ b/datapacks/bc_classes/data/common/powers/starting_items.json
@@ -1,4 +1,6 @@
 {
+    "name": "Starting Gear",
+    "description": "You start with 8 Pokéballs, 8 Great Balls, 32 pieces of bread, and Running Shoes",
     "type": "origins:starting_equipment",
     "stacks":
     [

--- a/datapacks/bc_classes/data/common/powers/starting_items.json
+++ b/datapacks/bc_classes/data/common/powers/starting_items.json
@@ -21,6 +21,10 @@
             "amount": 8
         },
         {
+            "item": "cobblemon:potion",
+            "amount": 3
+        },
+        {
             "item": "minecraft:bread",
             "amount": 32
         },

--- a/datapacks/bc_classes/data/common/powers/starting_items.json
+++ b/datapacks/bc_classes/data/common/powers/starting_items.json
@@ -18,7 +18,7 @@
         },
         {
             "item": "cobblemon:great_ball",
-            "amount": 8
+            "amount": 2
         },
         {
             "item": "cobblemon:potion",

--- a/datapacks/bc_classes/data/common/powers/starting_items.json
+++ b/datapacks/bc_classes/data/common/powers/starting_items.json
@@ -1,6 +1,14 @@
 {
     "name": "Starting Gear",
     "description": "You start with 8 Pokéballs, 8 Great Balls, 32 pieces of bread, and Running Shoes",
+    "badges":
+    [
+        {
+            "type": "origins:tooltip",
+            "sprite": "cobblemon:textures/item/poke_balls/poke_ball.png",
+            "text": ""
+        }
+    ],
     "type": "origins:starting_equipment",
     "stacks":
     [

--- a/datapacks/bc_classes/data/common/powers/starting_items.json
+++ b/datapacks/bc_classes/data/common/powers/starting_items.json
@@ -1,0 +1,22 @@
+{
+    "type": "origins:starting_equipment",
+    "stacks":
+    [
+        {
+            "item": "cobblemon:poke_ball",
+            "amount": 8
+        },
+        {
+            "item": "cobblemon:great_ball",
+            "amount": 8
+        },
+        {
+            "item": "minecraft:bread",
+            "amount": 32
+        },
+        {
+            "item": "minecraft:leather_boots",
+            "tag": "{display: {Name: '{\"text\": \"Running Shoes\", \"italic\": false}'}, Unbreakable:1, AttributeModifiers:[{AttributeName:\"generic.movement_speed\",Amount:0.5,Slot:feet,Operation:2,Name:\"generic.movement_speed\",UUID:[I;-123919,11668,142627,-23336]}]}"
+        }
+    ]
+}

--- a/datapacks/bc_classes/data/farmer/origins/berry_farmer.json
+++ b/datapacks/bc_classes/data/farmer/origins/berry_farmer.json
@@ -1,6 +1,6 @@
 {
     "name": "Berry Farmer",
-    "description": "Your average Pokémon trainer.",
+    "description": "Pokémon trainer that specify in berry farming. Berry farmers start with a bundle of various berries.",
     "icon": "cobblemon:oran_berry",
     "order": 0,
     "impact": 0,

--- a/datapacks/bc_classes/data/farmer/origins/berry_farmer.json
+++ b/datapacks/bc_classes/data/farmer/origins/berry_farmer.json
@@ -1,0 +1,12 @@
+{
+    "name": "Berry Farmer",
+    "description": "Your average Pokémon trainer.",
+    "icon": "cobblemon:oran_berry",
+    "order": 0,
+    "impact": 0,
+    "powers":
+    [
+        "common:starting_items",
+        "farmer:starting_berries"
+    ]
+}

--- a/datapacks/bc_classes/data/farmer/powers/starting_berries.json
+++ b/datapacks/bc_classes/data/farmer/powers/starting_berries.json
@@ -1,6 +1,14 @@
 {
     "name": "Berry Bundle",
     "description": "You start with a bundle of various healing berries.",
+    "badges":
+    [
+        {
+            "type": "origins:tooltip",
+            "sprite": "minecraft:textures/item/bundle.png",
+            "text": ""
+        }
+    ],
     "type": "origins:starting_equipment",
     "stacks":
     [

--- a/datapacks/bc_classes/data/farmer/powers/starting_berries.json
+++ b/datapacks/bc_classes/data/farmer/powers/starting_berries.json
@@ -1,4 +1,6 @@
 {
+    "name": "Berry Bundle",
+    "description": "You start with a bundle of various healing berries.",
     "type": "origins:starting_equipment",
     "stacks":
     [

--- a/datapacks/bc_classes/data/farmer/powers/starting_berries.json
+++ b/datapacks/bc_classes/data/farmer/powers/starting_berries.json
@@ -1,6 +1,6 @@
 {
     "name": "Berry Bundle",
-    "description": "You start with a bundle of various healing berries.",
+    "description": "You start with a bundle of various healing berries and mulch.",
     "badges":
     [
         {
@@ -14,7 +14,7 @@
     [
         {
             "item": "minecraft:bundle",
-            "tag": "{Items: [{id: \"cobblemon:persim_berry\", Count: 3b}, {id: \"cobblemon:aspear_berry\", Count: 3b}, {id: \"cobblemon:rawst_berry\", Count: 3b}, {id: \"cobblemon:pecha_berry\", Count: 3b}, {id: \"cobblemon:chesto_berry\", Count: 3b}, {id: \"cobblemon:cheri_berry\", Count: 3b}, {id: \"cobblemon:leppa_berry\", Count: 3b}, {id: \"cobblemon:oran_berry\", Count: 3b}]}"
+            "tag": "{Items: [{id: \"cobblemon:oran_berry\", Count: 3b}, {id: \"cobblemon:leppa_berry\", Count: 3b}, {id: \"cobblemon:pecha_berry\", Count: 3b}, {id: \"cobblemon:growth_mulch\", Count: 8b}]}"
         }
     ]
 }

--- a/datapacks/bc_classes/data/farmer/powers/starting_berries.json
+++ b/datapacks/bc_classes/data/farmer/powers/starting_berries.json
@@ -1,0 +1,10 @@
+{
+    "type": "origins:starting_equipment",
+    "stacks":
+    [
+        {
+            "item": "minecraft:bundle",
+            "tag": "{Items: [{id: \"cobblemon:persim_berry\", Count: 3b}, {id: \"cobblemon:aspear_berry\", Count: 3b}, {id: \"cobblemon:rawst_berry\", Count: 3b}, {id: \"cobblemon:pecha_berry\", Count: 3b}, {id: \"cobblemon:chesto_berry\", Count: 3b}, {id: \"cobblemon:cheri_berry\", Count: 3b}, {id: \"cobblemon:leppa_berry\", Count: 3b}, {id: \"cobblemon:oran_berry\", Count: 3b}]}"
+        }
+    ]
+}

--- a/datapacks/bc_classes/data/nurse/origins/nurse.json
+++ b/datapacks/bc_classes/data/nurse/origins/nurse.json
@@ -1,0 +1,12 @@
+{
+    "name": "Nurse",
+    "description": "A cousin to the popular Nurse Joy family, these Nurses travel around with extra healing items to help those in need.",
+    "icon": "cobblemon:potion",
+    "order": 2,
+    "impact": 0,
+    "powers":
+    [
+        "common:starting_items",
+        "nurse:starting_healing_items"
+    ]
+}

--- a/datapacks/bc_classes/data/nurse/powers/starting_healing_items.json
+++ b/datapacks/bc_classes/data/nurse/powers/starting_healing_items.json
@@ -1,0 +1,32 @@
+{
+    "name": "Doctor's Bag",
+    "description": "You start with extra healing items.",
+    "badges":
+    [
+        {
+            "type": "origins:tooltip",
+            "sprite": "cobblemon:textures/item/medicine/full_heal.png",
+            "text": ""
+        }
+    ],
+    "type": "origins:starting_equipment",
+    "stacks":
+    [
+        {
+            "item": "cobblemon:potion",
+            "amount": 8
+        },
+        {
+            "item": "cobblemon:super_potion",
+            "amount": 1
+        },
+        {
+            "item": "cobblemon:full_heal",
+            "amount": 5
+        },
+        {
+            "item": "cobblemon:heal_ball",
+            "amount": 3
+        }
+    ]
+}

--- a/datapacks/bc_classes/data/origins-classes/origin_layers/class.json
+++ b/datapacks/bc_classes/data/origins-classes/origin_layers/class.json
@@ -5,6 +5,7 @@
     "origins":
     [
         "trainer:trainer",
-        "farmer:berry_farmer"
+        "farmer:berry_farmer",
+        "nurse:nurse"
     ]
 }

--- a/datapacks/bc_classes/data/origins-classes/origin_layers/class.json
+++ b/datapacks/bc_classes/data/origins-classes/origin_layers/class.json
@@ -4,6 +4,7 @@
     "allow_random": false,
     "origins":
     [
-        "trainer:trainer"
+        "trainer:trainer",
+        "farmer:berry_farmer"
     ]
 }

--- a/datapacks/bc_classes/data/origins-classes/origin_layers/class.json
+++ b/datapacks/bc_classes/data/origins-classes/origin_layers/class.json
@@ -4,6 +4,6 @@
     "allow_random": false,
     "origins":
     [
-        "origins-classes:nitwit"
+        "trainer:trainer"
     ]
 }

--- a/datapacks/bc_classes/data/origins-classes/origin_layers/class.json
+++ b/datapacks/bc_classes/data/origins-classes/origin_layers/class.json
@@ -1,0 +1,9 @@
+{
+    "replace": true,
+    "order": 10,
+    "allow_random": false,
+    "origins":
+    [
+        "origins-classes:nitwit"
+    ]
+}

--- a/datapacks/bc_classes/data/trainer/origins/trainer.json
+++ b/datapacks/bc_classes/data/trainer/origins/trainer.json
@@ -1,0 +1,11 @@
+{
+    "name": "Trainer",
+    "description": "Your average Pokémon trainer.",
+    "icon": "cobblemon:poke_ball",
+    "order": 0,
+    "impact": 0,
+    "powers":
+    [
+        "common:starting_items"
+    ]
+}

--- a/datapacks/bc_classes/pack.mcmeta
+++ b/datapacks/bc_classes/pack.mcmeta
@@ -1,7 +1,7 @@
 {
     "pack":
     {
-        "pack_format": 17,
+        "pack_format": 15,
         "description": "Classes for the Block Circus Cobblemon server."
     }
 }

--- a/datapacks/bc_classes/pack.mcmeta
+++ b/datapacks/bc_classes/pack.mcmeta
@@ -1,0 +1,7 @@
+{
+    "pack":
+    {
+        "pack_format": 17,
+        "description": "Classes for the Block Circus Cobblemon server."
+    }
+}

--- a/datapacks/bc_origins/pack.mcmeta
+++ b/datapacks/bc_origins/pack.mcmeta
@@ -1,7 +1,7 @@
 {
     "pack":
     {
-        "pack_format": 17,
+        "pack_format": 15,
         "description": "Origins for the Block Circus Cobblemon server."
     }
 }


### PR DESCRIPTION
### Description
Created basic Pokémon trainer classes. Fixed datapack versions.

### Changes
**Trainer**
Starts with the basic trainer items, essentially the "Nitwit"
- 8x Pokéballs
- 2x Great balls
- 3x Potions
- 32x Bread
- Running Shoes
  - Unbreakable Leather Boots with a 50% movement speed bonus

**Berry Farmer**
- Basic Trainer Items
- Bundle Containing:
  - 3x Oran Berries
  - 3x Leppa Berries
  - 3x Pecha Berries
  - 8x Growth Mulch

**Nurse**
- 8x Potion (in addition to the base 3)
- 1x Super Potion
- 5x Full Heals
- 3x Heal Balls